### PR TITLE
Adds gem quiet_assets to app template

### DIFF
--- a/setup/app_template.rb
+++ b/setup/app_template.rb
@@ -11,6 +11,7 @@ gem_group :development, :test do
   gem 'rspec-nc', require: false
   gem 'pry-rails'
   gem 'faker'
+  gem 'quiet_assets'
 end
 
 gem_group :test do


### PR DESCRIPTION
Qué les parece agregar [esta gem](https://github.com/evrone/quiet_assets) al app template?

Para mí el 99% del tiempo el output de los assets no me sirve de nada. Pero de todas maneras, para el 1% del tiempo restante, se puede _deshabilitar la deshabilitación_ poniendo temporalmente `config.quiet_assets = false` en el `application.rb`

A ver qué dicen los railistas @iobaixas @emilioeduardob @ldlsegovia 
