### PR TITLE
Use aliases for ruby-version in projects

### DIFF
--- a/protocol/ruby/README.md
+++ b/protocol/ruby/README.md
@@ -4,6 +4,18 @@ Ruby Projects Protocol
 A guide to work around the hassle of activating the right gem, using
 the right ruby, and everything ruby related
 
+Ruby version
+------------
+
+When defining a ruby, use the version without patch. This way if you change
+the patch version of a ruby installation your project will continue to work.
+
+```
+# Instead of this
+2.0.0-p451
+# Use this
+2.0.0
+```
 
 Bundle exec and binstubs
 ------------------------


### PR DESCRIPTION
Any thoughts on this??

Maybe a particular project has a need to run a specific patch version of ruby, but that should be the exception.
Also this should makes easy to maintain the server with compatible versions.
