### PR TITLE
herramientas de debugging en rails

### DIFF
--- a/setup/app_template.rb
+++ b/setup/app_template.rb
@@ -67,7 +67,7 @@ ask_for_active_admin
 gem_group :development, :test do
   gem "rspec-rails"
   gem 'factory_girl_rails'
-  gem 'debugger', require: 'ruby-debug'
+  gem 'pry-byebug'
   gem 'zeus'
   gem 'guard-rspec', require: false
   gem 'rspec-nc', require: false


### PR DESCRIPTION
Me dio problemas para actualizar la siguiente línea:

``` ruby
gem 'debugger', require: 'ruby-debug'
```

La solución rápida fue cambiar `debugger` por `byebug`. Sin embargo, me cuestiono un poco su utilidad sobre todo porque ya se encuentra `pry-rails` que puede hacer lo mismo. ¿Les parece quitar agregar `byebug` en vez de `debugger` o suprimir `debugger` simplemente?
