### PR TITLE
Update fontawesome-bower-rails.md

### DIFF
--- a/setup/fontawesome-bower-rails.md
+++ b/setup/fontawesome-bower-rails.md
@@ -16,27 +16,25 @@ Add the following code snippet to your `application.rb` or `production.rb`
 config.assets.precompile << Proc.new { |path| path =~ /font-awesome\/fonts/ and File.extname(path).in?(['.otf', '.eot', '.svg', '.ttf', '.woff']) }
 ```
 
-3. Modify the `@font_face` variable to use the assets urls
+3. Modify the `fa-font-path` variable to use the assets urls
 
-Create a new .less stylesheet asset with the following content (for sass just use sass syntax):
+Create a new .less or .scss stylesheet asset with the following content:
+
+Less
 
 ```less
-@font-face {
-  font-family: 'FontAwesome';
-  src: font-url('font-awesome/fonts/fontawesome-webfont.eot?v=@{fa-version}');
-  src: font-url('font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=@{fa-version}') format('embedded-opentype'),
-  font-url('font-awesome/fonts/fontawesome-webfont.woff?v=@{fa-version}') format('woff'),
-  font-url('font-awesome/fonts/fontawesome-webfont.ttf?v=@{fa-version}') format('truetype'),
-  font-url('font-awesome/fonts/fontawesome-webfont.svg?v=@{fa-version}#fontawesomeregular') format('svg');
-  font-weight: normal;
-  font-style: normal;
-}
+@fa-font-path: "font-awesome/fonts";
 ```
 
-Then include it in your main `aplication.less` file under the font-awesome css inclusion:
+SCSS
+
+```scss
+$fa-font-path: "font-awesome/fonts";
+```
+
+Then include it in your main `aplication.(less|scss)` file under the font-awesome css inclusion:
 
 ```less
-@import "font-awesome/less/font-awesome";
 @import "font-paths";
+@import "font-awesome/less/font-awesome";
 ```
-


### PR DESCRIPTION
I've included SCSS examples and simplified the customisation, only the @fa-font-path variable needs to be edited and included before the main font awesome file. I've tested this with SCSS but not Less so, I assume Less variables can be overloaded in the same way as SCSS.
